### PR TITLE
[FEATURE]: Allow config with inheritance

### DIFF
--- a/config/resolver_test.go
+++ b/config/resolver_test.go
@@ -23,6 +23,18 @@ type myConfig struct {
 	Foo foo
 }
 
+type inheritingConfig struct {
+	foo
+	AnotherFieldToSet string
+}
+
+func (c *inheritingConfig) Verify() error {
+	if len(c.AnotherFieldToSet) == 0 {
+		c.AnotherFieldToSet = "set"
+	}
+	return nil
+}
+
 func TestValidatorImpl_VerifyShouldSetDefaultValue(t *testing.T) {
 	mc := &myConfig{}
 	v := &validatorImpl{
@@ -30,6 +42,16 @@ func TestValidatorImpl_VerifyShouldSetDefaultValue(t *testing.T) {
 	}
 	_ = v.Verify()
 	assert.Equal(t, "set", mc.Foo.FieldToSet)
+}
+
+func TestValidatorImpl_VerifyShouldCallChildAndParent(t *testing.T) {
+	mc := &inheritingConfig{}
+	v := &validatorImpl{
+		config: mc,
+	}
+	_ = v.Verify()
+	assert.Equal(t, "set", mc.FieldToSet)
+	assert.Equal(t, "set", mc.AnotherFieldToSet)
 }
 
 func TestResolveImpl_WatchConfigShouldNotifyOnlyWhenValuesChange(t *testing.T) {


### PR DESCRIPTION
This is a draft PR with only the test for now, to highlight an issue / "feature lack" of inheriting another go struct into the config. 

~The problem is that only the parent struct's Verify function is called.~

Edit: Actually this is working when Foo is exposed: foo -> Foo on the struct name. I think then it creates a virtual Foo field and considered by the reflection as a field ? I'm not sure but when we expose it it works. 