### PR TITLE
[BREAKINGCHANGE] Support cron job syntax and change the actual WithCron method

### DIFF
--- a/async/taskhelper/basic_runner.go
+++ b/async/taskhelper/basic_runner.go
@@ -1,0 +1,100 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskhelper
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/perses/common/async"
+	"github.com/sirupsen/logrus"
+)
+
+type runner struct {
+	Helper
+	// interval is used when the runner is used as a Cron
+	interval time.Duration
+	// task can be a SimpleTask or a Task
+	task         interface{}
+	isSimpleTask bool
+	done         chan struct{}
+}
+
+func (r *runner) Done() <-chan struct{} {
+	return r.done
+}
+
+func (r *runner) String() string {
+	return r.task.(async.SimpleTask).String()
+}
+
+func (r *runner) Start(ctx context.Context, cancelFunc context.CancelFunc) (err error) {
+	// closing this channel will highlight the caller that the task is done.
+	defer close(r.done)
+	childCtx := ctx
+	if !r.isSimpleTask {
+		// childCancelFunc will be used to stop any sub go-routing using the childCtx when the current task is stopped.
+		// it's just to be sure that every sub go-routing created by the task will be stopped without stopping the whole application.
+		var childCancelFunc context.CancelFunc
+		childCtx, childCancelFunc = context.WithCancel(ctx)
+		t := r.task.(async.Task)
+		// then we have to call the finalize method of the task
+		defer func() {
+			childCancelFunc()
+			if finalErr := t.Finalize(); finalErr != nil {
+				if err == nil {
+					err = finalErr
+				} else {
+					logrus.WithError(finalErr).Error("error occurred when calling the method Finalize of the task")
+				}
+			}
+		}()
+
+		// and the initialize method
+		if initError := t.Initialize(); initError != nil {
+			err = fmt.Errorf("unable to call the initialize method of the task: %w", initError)
+			return
+		}
+	}
+
+	// then run the task
+	if executeErr := r.task.(async.SimpleTask).Execute(childCtx, cancelFunc); executeErr != nil {
+		err = fmt.Errorf("unable to call the execute method of the task: %w", executeErr)
+		return
+	}
+
+	// in case the runner has an interval properly set, then we can create a ticker and periodically call the method that executes the task
+	return r.tick(childCtx, cancelFunc)
+}
+
+func (r *runner) tick(ctx context.Context, cancelFunc context.CancelFunc) error {
+	simpleTask := r.task.(async.SimpleTask)
+	if r.interval <= 0 {
+		return nil
+	}
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if executeErr := simpleTask.Execute(ctx, cancelFunc); executeErr != nil {
+				return fmt.Errorf("unable to call the execute method of the task %s: %w", simpleTask.String(), executeErr)
+			}
+		case <-ctx.Done():
+			logrus.Debugf("task %s has been canceled", simpleTask.String())
+			return nil
+		}
+	}
+}

--- a/async/taskhelper/cron_runner.go
+++ b/async/taskhelper/cron_runner.go
@@ -1,0 +1,96 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskhelper
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/perses/common/async"
+	"github.com/robfig/cron"
+	"github.com/sirupsen/logrus"
+)
+
+type cronRunner struct {
+	Helper
+	// schedule is used to now when calling the task
+	schedule cron.Schedule
+	// task can be a SimpleTask or a Task
+	task         interface{}
+	isSimpleTask bool
+	done         chan struct{}
+}
+
+func (r *cronRunner) Done() <-chan struct{} {
+	return r.done
+}
+
+func (r *cronRunner) String() string {
+	return r.task.(async.SimpleTask).String()
+}
+
+func (r *cronRunner) Start(ctx context.Context, cancelFunc context.CancelFunc) (err error) {
+	// closing this channel will highlight the caller that the task is done.
+	defer close(r.done)
+	childCtx := ctx
+	if !r.isSimpleTask {
+		// childCancelFunc will be used to stop any sub go-routing using the childCtx when the current task is stopped.
+		// it's just to be sure that every sub go-routing created by the task will be stopped without stopping the whole application.
+		var childCancelFunc context.CancelFunc
+		childCtx, childCancelFunc = context.WithCancel(ctx)
+		t := r.task.(async.Task)
+		// then we have to call the finalize method of the task
+		defer func() {
+			childCancelFunc()
+			if finalErr := t.Finalize(); finalErr != nil {
+				if err == nil {
+					err = finalErr
+				} else {
+					logrus.WithError(finalErr).Error("error occurred when calling the method Finalize of the task")
+				}
+			}
+		}()
+
+		// and the initialize method
+		if initError := t.Initialize(); initError != nil {
+			err = fmt.Errorf("unable to call the initialize method of the task: %w", initError)
+			return
+		}
+	}
+	return r.cron(childCtx, cancelFunc)
+}
+
+func (r *cronRunner) cron(ctx context.Context, cancelFunc context.CancelFunc) error {
+	simpleTask := r.task.(async.SimpleTask)
+	now := time.Now()
+	next := r.schedule.Next(now)
+	for {
+		timer := time.NewTimer(next.Sub(now))
+		for {
+			select {
+			case now = <-timer.C:
+				// then run the task
+				if executeErr := r.task.(async.SimpleTask).Execute(ctx, cancelFunc); executeErr != nil {
+					return fmt.Errorf("unable to call the execute method of the task: %w", executeErr)
+				}
+				next = r.schedule.Next(now)
+			case <-ctx.Done():
+				logrus.Debugf("task %s has been canceled", simpleTask.String())
+				return nil
+			}
+			break
+		}
+	}
+}

--- a/async/taskhelper/helper_test.go
+++ b/async/taskhelper/helper_test.go
@@ -78,12 +78,16 @@ func TestJoinAll(t *testing.T) {
 	t1, err := New(&simpleTaskImpl{})
 	assert.NoError(t, err)
 	complexTask := &complexTaskImpl{}
-	t2, err := NewCron(complexTask, 5*time.Second)
+	anotherComplexTask := &complexTaskImpl{}
+	t2, err := NewTick(complexTask, 5*time.Second)
+	assert.NoError(t, err)
+	t3, err := NewCron(anotherComplexTask, "@hourly")
 	assert.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	// start all runner
 	Run(ctx, cancel, t1)
 	Run(ctx, cancel, t2)
-	JoinAll(ctx, 30*time.Second, []Helper{t1, t2})
+	Run(ctx, cancel, t3)
+	JoinAll(ctx, 30*time.Second, []Helper{t1, t2, t3})
 	assert.True(t, complexTask.counter >= 2)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/nexucis/lamenv v0.5.2
 	github.com/prometheus/client_golang v1.19.0
 	github.com/prometheus/common v0.48.0
+	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/otel v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/prometheus/common v0.48.0 h1:QO8U2CdOzSn1BBsmXJXduaaW+dY/5QLjfB8svtSz
 github.com/prometheus/common v0.48.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=


### PR DESCRIPTION
This PR is introducing the possibility to execute a task or a simple task using the cron syntax.

It's a breaking change because the method `WithCronTask` has been modified to consider this new syntax instead of the simple duration.

The previous `WithCronTask` has been renamed by `WithTimerTask`