### PR TITLE
[BUGFIX]: conflicting Schema URL: https://opentelemetry.io/schemas/1.25.0 and https://opentelemetry.io/schemas/1.12.0"

### DIFF
--- a/otel/provider.go
+++ b/otel/provider.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 )
 
 type Builder struct {
@@ -77,8 +77,7 @@ func (b *Builder) Build() (async.Task, error) {
 func (b *Builder) createDefaultResource(serviceName string) (*resource.Resource, error) {
 	return resource.Merge(
 		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
+		resource.NewSchemaless(
 			semconv.ServiceNameKey.String(serviceName),
 			semconv.ServiceVersionKey.String(version.Version)))
 }


### PR DESCRIPTION
I propose to remove the schema from the merge to mitigate the following issue 
```
FATA[2024-06-27T14:57:05+02:00] An error occurred while creating the OTeL provider task  error="conflicting Schema URL: https://opentelemetry.io/schemas/1.25.0 and https://opentelemetry.io/schemas/1.12.0"
```

The nightmare of it is explained in the following issue
https://github.com/open-telemetry/opentelemetry-go/issues/2341
old wording for same error. Now at least they provide the two conflicting schema. 

We could also keep schema and make a test of start on each PR, guaranteeing that the version of semconv align with default but in my opinion, as long as we merge with default containing the default schema that's fine.