### PR TITLE
Fix example for async.Async()

### DIFF
--- a/async/async.go
+++ b/async/async.go
@@ -17,18 +17,19 @@
 // It should be used when you need to run multiple asynchronous task and wait for each of them to finish.
 // Example:
 //
-//	 func doneAsync() int {
+//	 func doneAsync() (int, error) {
 //			// asynchronous task
 //			time.Sleep(3 * time.Second)
-//			return 1
+//			return 1, nil
 //		}
 //
 //	 func synchronousTask() {
-//	 	n := async.Async(doneAsync)
-//			// do some other stuff
+//	 	next := async.Async(doneAsync)
+//		// do some other stuff
 //	 	// then wait for the end of the asynchronous task and get back the result
-//	 	result := next.Await()
+//	 	result, err := next.Await()
 //	 	// do something with the result
+//		fmt.Println("got",result,"err",err)
 //	 }
 //
 // It is useful to use this implementation when you want to paralyze quickly some short function like paralyzing multiple HTTP requests.

--- a/async/example_test.go
+++ b/async/example_test.go
@@ -1,0 +1,36 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package async_test
+
+import (
+	"fmt"
+
+	"github.com/perses/common/async"
+)
+
+func fn(s string, err error) func() (string, error) {
+	return func() (string, error) {
+		return s, err
+	}
+}
+
+func ExampleAsync() {
+	next1 := async.Async(fn("success", nil))
+	next2 := async.Async(fn("", fmt.Errorf("error")))
+
+	result1, err1 := next1.Await()
+	result2, err2 := next2.Await()
+	fmt.Println("async1:", result1, err1, "async2:", result2, err2)
+	// Output: async1: success <nil> async2:  error
+}


### PR DESCRIPTION
This commit also adds a testable example [1] which demonstrates the Async()/Await() pattern.

[1] https://go.dev/blog/examples